### PR TITLE
Add option for passing a callback function to server.start function

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -73,7 +73,9 @@ jsonApi.metrics.on('data', data => {
 // If we're using the example server for the test suite,
 // wait for the tests to call .start();
 if (typeof describe === 'undefined') {
-  jsonApi.start()
+  jsonApi.start(() => {
+    console.log('Server running')
+  })
 }
 server.start = jsonApi.start
 server.close = jsonApi.close

--- a/lib/jsonApi.js
+++ b/lib/jsonApi.js
@@ -111,12 +111,12 @@ jsonApi.onUncaughtException = errHandler => {
 
 jsonApi.getExpressServer = () => router.getExpressServer()
 
-jsonApi.start = () => {
+jsonApi.start = (cb) => {
   schemaValidator.validate(jsonApi._resources)
   router.applyMiddleware()
   routes.register()
   if (!jsonApi._apiConfig.router) {
-    router.listen(jsonApi._apiConfig.port)
+    router.listen(jsonApi._apiConfig.port, cb)
   }
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -83,14 +83,14 @@ router.applyMiddleware = () => {
   })
 }
 
-router.listen = port => {
+router.listen = (port, cb) => {
   if (!server) {
     if (jsonApi._apiConfig.protocol === 'https') {
       server = require('https').createServer(jsonApi._apiConfig.tls || {}, app)
     } else {
       server = require('http').createServer(app)
     }
-    server.listen(port)
+    server.listen(port, cb)
   }
 }
 

--- a/types/jsonApi.d.ts
+++ b/types/jsonApi.d.ts
@@ -38,5 +38,5 @@ export const getExpressServer: () => Application
 export const ChainHandler: typeof ChainHandlerType
 export const MemoryHandler: typeof MemoryHandlerType
 export function onUncaughtException(err: Error): void
-export function start(): void
+export function start(cb: () => void): void
 export function close(): void


### PR DESCRIPTION
We can pass a function to the server.start function as a callback function.